### PR TITLE
Remove `Failure.code` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ An error handling library for portable unrecoverable errors.
 
 This crate provides,
 
-- `Failure` struct that represents an unrecoverable error with an error code, message and user-level backtrace
-  - Error code and message are optional
+- `Failure` struct that represents an unrecoverable error with an error message and user-level backtrace
+  - Error message is optional
   - Constituted with simple types (`u32`, `String`, and `Vec` of those)
     - Portable across process and language boundaries
     - Optional `serde` support ("serde" feature)
@@ -43,7 +43,7 @@ assert_eq!(safe_div(4, 2), Ok(2));
 assert_eq!(safe_div(4, 0).err().map(|e| e.to_string()),
            Some(
 r#"failed due to "expected `true` but got `false`"
-  at src/lib.rs:7
-  at src/lib.rs:12
+  at src/lib.rs:8
+  at src/lib.rs:13
 "#.to_owned()));
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! This crate provides,
 //!
-//! - [`Failure`] struct that represents an unrecoverable error with an error code, message and user-level backtrace
-//!   - Error code and message are optional
+//! - [`Failure`] struct that represents an unrecoverable error with an error message and user-level backtrace
+//!   - Error message is optional
 //!   - Constituted with simple types ([`u32`], [`String`], and [`Vec`] of those)
 //!     - Portable across process and language boundaries
 //!     - Optional [`serde`] support ("serde" feature)


### PR DESCRIPTION
Reasons:
- I hardly use this field
- Code information can be embedded in the message string
- If user want to write conditional code depending on the error code, it would be better to use other error handling crates that keep source error types